### PR TITLE
Color picker is not work properly with Firefox.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -29,6 +29,8 @@
       <!-- main -->
       <script type="text/javascript" src="paints_chainer.js"></script>
   <!-- fileend -->
+  <!-- wColorPicker workaround for Firefox -->
+  <style type="text/css">.wColorPicker-palettes-holder {white-space: nowrap;}</style>
 </head>
 <body>
 


### PR DESCRIPTION
Currently, main color palette is not shown with Firefox.
This is an upstream issue of wColorPicker.

![screenshot11](https://cloud.githubusercontent.com/assets/11642/22384102/31624170-e510-11e6-9b62-8db092e5267e.png)

Here is a simple workaround.