### PR TITLE
Remove redundant calls (encode and decode)

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,21 +48,18 @@ class MyHandler(http.server.CGIHTTPRequestHandler):
            id_str = "test"
          
         if "line" in form:
-           bin1 = form["line"][0]
-           bin1 = bin1.decode().split(",")[1]
-           bin1 = base64.b64decode(bin1.encode())
+           bin1 = form["line"][0].split(b",")[1]
+           bin1 = base64.b64decode(bin1)
            fout1 = open ( "./static/images/line/"+id_str+".png", 'wb')
-           fout1.write (bin1)
+           fout1.write(bin1)
            fout1.close()
 
         if "ref" in form:
-           bin2 = form["ref"][0]
-           bin2 = bin2.decode().split(",")[1]
-           bin2 = base64.b64decode(bin2.encode())
+           bin2 = form["ref"][0].split(b",")[1]
+           bin2 = base64.b64decode(bin2)
            fout2 = open ( "./static/images/ref/"+id_str+".png", 'wb')
-           fout2.write (bin2)
+           fout2.write(bin2)
            fout2.close()
- 
 
         blur = 0
         if "blur" in form:


### PR DESCRIPTION
Python 3 accepts `split(b",")`.